### PR TITLE
Added Subfolder retention capability

### DIFF
--- a/conv2mp4-ps.ps1
+++ b/conv2mp4-ps.ps1
@@ -734,8 +734,14 @@ Begin search loop
 	{
 		$i++;
 		$oldFile = $file.DirectoryName + "\" + $file.BaseName + $file.Extension;
+		$FileSubfolders = ($file.DirectoryName).Substring($mediaPath.Length,($file.DirectoryName).Length-$mediaPath.Length);
 		If ($useOutPath -eq $True)
 		{
+			$outpath += $FileSubfolders;
+			IF (-Not (test-path $outpath))
+			{
+				md $outpath
+			}
 			$newFile = $outPath + "\" + $file.BaseName + ".mp4";
 			Log "outPath = $outPath"
 		}


### PR DESCRIPTION
Maintains subfolders when converting files. This allows for saving files directly into plex library Movie/TV Show/etc folders when using $outpath. Simply create a folder with subfolders matching those in the plex library. This is especially useful when converting several seasons of a show at once as it maintains the season organization.

Example:
Unconverted Media Location : C:\Documents\Files to Convert\TV Shows\Show Name\Season 1\Filename

$mediaPath = C:\Documents/Files to Convert
$outPath = D:\Plex

Converted Media Location: D:\Plex\TV Shows\Show Name\Season 1\Filename
