### PR TITLE
Keep subfolder structure when saving to Outpath

### DIFF
--- a/conv2mp4-ps.ps1
+++ b/conv2mp4-ps.ps1
@@ -729,7 +729,7 @@ Begin search loop
 
 # Begin performing operations of files
 	$i = 0
-
+	$baseOutPath = $outpath;
 	ForEach ($file in $fileList)
 	{
 		$i++;
@@ -737,10 +737,10 @@ Begin search loop
 		$FileSubfolders = ($file.DirectoryName).Substring($mediaPath.Length,($file.DirectoryName).Length-$mediaPath.Length);
 		If ($useOutPath -eq $True)
 		{
-			$outpath += $FileSubfolders;
+			$outPath = $baseOutPath + $FileSubfolders;
 			IF (-Not (test-path $outpath))
 			{
-				md $outpath
+				md $outPath
 			}
 			$newFile = $outPath + "\" + $file.BaseName + ".mp4";
 			Log "outPath = $outPath"

--- a/conv2mp4-ps.ps1
+++ b/conv2mp4-ps.ps1
@@ -734,8 +734,14 @@ Begin search loop
 	{
 		$i++;
 		$oldFile = $file.DirectoryName + "\" + $file.BaseName + $file.Extension;
+		$FileSubfolders = ($file.DirectoryName).Substring($mediaPath.Length,($file.DirectoryName).Length-$mediaPath.Length);
 		If ($useOutPath -eq $True)
 		{
+			$outpath += $FileSubfolders;
+			IF (-Not (test-path $outpath))
+			{
+				md $outpath
+			}
 			$newFile = $outPath + "\" + $file.BaseName + ".mp4";
 			Log "outPath = $outPath"
 		}


### PR DESCRIPTION
Fixed a bug in my last version that was recursively creating folders within folders instead of all in one folder.

I don't have a lot of files to test this on hence the initial bug so I would recommend running it with a few test cases before integrating it.