### PR TITLE
Plex library no longer refreshes when no action is taken on file

### DIFF
--- a/conv2mp4-ps.ps1
+++ b/conv2mp4-ps.ps1
@@ -122,7 +122,7 @@ ForEach ($file in $fileList) {
         }
 
         # Refresh Plex libraries
-        If ($cfg.use_plex) {
+        If ($cfg.use_plex -AND (-Not($skipFile))) {
             PlexRefresh
         }
 


### PR DESCRIPTION
Plex library was being unnecessarily refreshed when a compliant file was processed