### PR TITLE
Merge feature/metadata-parsing into develop

### DIFF
--- a/conv2mp4-ps.ps1
+++ b/conv2mp4-ps.ps1
@@ -1,5 +1,5 @@
 <#======================================================================================================================
-conv2mp4-ps v4.1.3 - https://github.com/BrianDMG/conv2mp4-ps
+conv2mp4-ps v4.2 - https://github.com/BrianDMG/conv2mp4-ps
 
 This Powershell script will recursively search through a user-defined file path and convert all videos of user-specified
 include_file_types to MP4 with H264 video and AAC audio using ffmpeg. If a conversion failure is detected, the script re-encodes

--- a/conv2mp4-ps.ps1
+++ b/conv2mp4-ps.ps1
@@ -1,5 +1,5 @@
 <#======================================================================================================================
-conv2mp4-ps v4.1.2 - https://github.com/BrianDMG/conv2mp4-ps
+conv2mp4-ps v4.1.3 - https://github.com/BrianDMG/conv2mp4-ps
 
 This Powershell script will recursively search through a user-defined file path and convert all videos of user-specified
 include_file_types to MP4 with H264 video and AAC audio using ffmpeg. If a conversion failure is detected, the script re-encodes

--- a/conv2mp4-ps.ps1
+++ b/conv2mp4-ps.ps1
@@ -47,7 +47,7 @@ ForEach ($file in $fileList) {
     $fileSubDirs = ($file.DirectoryName).Substring($cfg.media_path.Length, ($file.DirectoryName).Length - $cfg.media_path.Length)
 
     If ($cfg.use_out_path) {
-        $targetPath = $targetFile = $cfg.out_path + $fileSubDirs + "\"
+        $targetPath = $cfg.out_path + $fileSubDirs + "\"
 
         If (-Not (Test-Path $targetPath)) {
             mkdir $targetPath -Force
@@ -71,13 +71,6 @@ ForEach ($file in $fileList) {
     #Set targetFile final name
     If ($cfg.use_out_path) {
         $targetFileRenamed = $targetPath + $file.BaseName + ".mp4"
-
-        #If using out_path, create target path if it doesn't exist
-        If ($cfg.use_out_path) {
-            If (-Not (Test-Path $targetPath)) {
-                mkdir $$targetPath -Force
-            }
-        }
     }
     Else {
         $targetFileRenamed = $file.DirectoryName + "\" + $file.BaseName + ".mp4"

--- a/conv2mp4-ps.ps1
+++ b/conv2mp4-ps.ps1
@@ -53,10 +53,10 @@ ForEach ($file in $fileList) {
             mkdir $targetPath -Force
         }
 
-        $targetFile = $targetPath + $file.BaseName + "_NEW" + ".mp4"
+        $targetFile = $targetPath + $file.BaseName + ".mp4" + ".conv2mp4"
     }
     Else {
-        $targetFile = $file.DirectoryName + "\" + $file.BaseName + "_NEW" + ".mp4"
+        $targetFile = $file.DirectoryName + "\" + $file.BaseName + ".mp4" + ".conv2mp4"
     }
 
     $progress = ($(@($fileList).indexOf($file)+1) / $fileList.Count) * 100
@@ -194,7 +194,7 @@ ForEach ($file in $fileList) {
             }
 
             #If $sourceFile was an mp4, rename $targetFile to remove "-NEW"
-            $targetFileRenamed = "$targetFile" -replace "_NEW",""
+            $targetFileRenamed = "$targetFile" -replace ".conv2mp4",""
             Move-Item $targetFile $targetFileRenamed
 
             #If using out_path, delete empty source directories

--- a/files/cfg/config.template
+++ b/files/cfg/config.template
@@ -32,4 +32,4 @@ plex_token=plextoken
 
 #Garbage collection
 collect_garbage = false
-garbage_include_file_types=*.nfo, *_NEW_
+garbage_include_file_types=*.nfo, *.conv2mp4

--- a/files/func/ConvertFile.ps1
+++ b/files/func/ConvertFile.ps1
@@ -102,7 +102,6 @@ Function ConvertFile {
                 $title = $title -replace '\W',' '
                 $year = $($title.split()[-1])
                 $title = $title.SubString(0, $title.LastIndexOf(' '))
-                $encodingTool = "conv2mp4-$($prop.platform) $($prop.version) - $($prop.github_url)"
 
                 $ffArgs += "-metadata " #Flag to specify key/value pairs for encoding metadata
                 $ffArgs += "title=`"$title`" " #Use $title variable as metadata 'title'
@@ -110,6 +109,7 @@ Function ConvertFile {
                 $ffArgs += "date=`"$year`" " #Use $year variable as metadata 'date'
             }
 
+            $encodingTool = "conv2mp4-$($prop.platform) $($prop.version) - $($prop.github_url)"
             $ffArgs += "-metadata " #Flag to specify key/value pairs for encoding metadata
             $ffArgs += "encoding_tool=`"$encodingTool`" " #Use $encodingTool variable as metadata 'encoding_tool'
         }

--- a/files/func/ConvertFile.ps1
+++ b/files/func/ConvertFile.ps1
@@ -99,7 +99,7 @@ Function ConvertFile {
             }
             #Otherwise it's assumed to be a movie
             Else {
-                $remove= $title | Select-String -Pattern '^(.*?)(\(?)((19|20)[0-9]{2})(.*$)'  | ForEach-Object { "$($_.matches.groups[3])" }
+                $remove= $title | Select-String -Pattern '^(.*?)(\(?)((19|20)[0-9]{2})(.*$)'  | ForEach-Object { "$($_.matches.groups[2,4,5])" }
                 $title = $title -replace "$remove",''
                 $title = $title -replace '\W',' '
                 $year = $($title.split()[-1])

--- a/files/func/ConvertFile.ps1
+++ b/files/func/ConvertFile.ps1
@@ -102,6 +102,7 @@ Function ConvertFile {
                 $remove= $title | Select-String -Pattern '^(.*?)(\(?)((19|20)[0-9]{2})(.*$)'  | ForEach-Object { "$($_.matches.groups[2,4,5])" }
                 $title = $title -replace "$remove",''
                 $title = $title -replace '\W',' '
+                $title=$($title.trim() -replace "\s+"," ")
                 $year = $($title.split()[-1])
                 $title = $title.SubString(0, $title.LastIndexOf(' '))
 

--- a/files/func/ConvertFile.ps1
+++ b/files/func/ConvertFile.ps1
@@ -95,7 +95,7 @@ Function ConvertFile {
                 $ffArgs += "-metadata " #Flag to specify key/value pairs for encoding metadata
                 $ffArgs += "title=`"$($episodeTitle.trim())`" " #Use $episodeTitleitle variable as metadata 'title'
                 $ffArgs += "-metadata " #Flag to specify key/value pairs for encoding metadata
-                $ffArgs += "comment=`"$unparsedTitle`" " #Use $episodeTitleitle variable as metadata 'title'
+                $ffArgs += "synopsis=`"$unparsedTitle`" " #Use $episodeTitleitle variable as metadata 'title'
             }
             #Otherwise it's assumed to be a movie
             Else {
@@ -111,9 +111,9 @@ Function ConvertFile {
                 $ffArgs += "date=`"$year`" " #Use $year variable as metadata 'date'
             }
 
-            $encodingTool = "conv2mp4-$($prop.platform) $($prop.version) - $($prop.github_url)"
+            $encodingTool = "Encoded by conv2mp4-$($prop.platform) $($prop.version) - $($prop.github_url) on $($time.Invoke())"
             $ffArgs += "-metadata " #Flag to specify key/value pairs for encoding metadata
-            $ffArgs += "encoding_tool=`"$encodingTool`" " #Use $encodingTool variable as metadata 'encoding_tool'
+            $ffArgs += "comment=`"$encodingTool`" " #Use $encodingTool variable as metadata 'encoding_tool'
         }
 
         $ffArgs += "-map " #Flag to use channel mapping

--- a/files/func/ConvertFile.ps1
+++ b/files/func/ConvertFile.ps1
@@ -95,7 +95,7 @@ Function ConvertFile {
                 $ffArgs += "-metadata " #Flag to specify key/value pairs for encoding metadata
                 $ffArgs += "title=`"$($episodeTitle.trim())`" " #Use $episodeTitleitle variable as metadata 'title'
                 $ffArgs += "-metadata " #Flag to specify key/value pairs for encoding metadata
-                $ffArgs += "synopsis=`"$unparsedTitle`" " #Use $episodeTitleitle variable as metadata 'title'
+                $ffArgs += "description=`"$unparsedTitle`" " #Use $episodeTitleitle variable as metadata 'title'
             }
             #Otherwise it's assumed to be a movie
             Else {
@@ -111,7 +111,7 @@ Function ConvertFile {
                 $ffArgs += "date=`"$year`" " #Use $year variable as metadata 'date'
             }
 
-            $encodingTool = "Encoded by conv2mp4-$($prop.platform) $($prop.version) - $($prop.github_url) on $($time.Invoke())"
+            $encodingTool = "Encoded by conv2mp4-$($prop.platform) v$($prop.version) ($($prop.github_url)) on $($time.Invoke())"
             $ffArgs += "-metadata " #Flag to specify key/value pairs for encoding metadata
             $ffArgs += "comment=`"$encodingTool`" " #Use $encodingTool variable as metadata 'encoding_tool'
         }
@@ -150,6 +150,7 @@ Function ConvertFile {
         Else {
             $ffArgs += "-sn " #Option to remove any existing subtitles
         }
+        $ffArgs+= "-f mp4 "
         $ffArgs += "`"$targetFile`"" #Output file
 
         $ffCMD = cmd.exe /c "$ffmpeg $ffArgs"

--- a/files/func/ConvertFile.ps1
+++ b/files/func/ConvertFile.ps1
@@ -75,7 +75,7 @@ Function ConvertFile {
 
             #Check if it's a TV episode
             If ($title -match 's\d+'){
-                Log 'matched tv'
+                $unparsedTitle = $title
                 $remove = $title | Select-String -Pattern '^(.*?)(S\d+)(E\d+)(\D+)(.*$)'  | ForEach-Object { "$($_.matches.groups[5])" }
                 $title = $title -replace "$remove",''
                 $title = $title -replace '\W',' '
@@ -87,13 +87,15 @@ Function ConvertFile {
                 $episodeTitle = $title | Select-String -Pattern '^(.*?)(S\d+)(E\d+)(\D+)(.*$)'  | ForEach-Object { "$($_.matches.groups[4])" }
 
                 $ffArgs += "-metadata " #Flag to specify key/value pairs for encoding metadata
-                $ffArgs += "show=`"$showTitle`" " #Use $showTitle variable as metadata 'show'
+                $ffArgs += "show=`"$($showTitle.trim())`" " #Use $showTitle variable as metadata 'show'
                 $ffArgs += "-metadata " #Flag to specify key/value pairs for encoding metadata
-                $ffArgs += "season_number=`"$seasonNumber`" " #Use $seasonNumber variable as metadata 'season_number'
+                $ffArgs += "season_number=`"$('{0:d2}' -f [int]$seasonNumber)`" " #Use $seasonNumber variable as metadata 'season_number'
                 $ffArgs += "-metadata " #Flag to specify key/value pairs for encoding metadata
-                $ffArgs += "episode_id=`"$episodeNumber`" " #Use $episodeNumber variable as metadata 'episode_id'
+                $ffArgs += "episode_id=`"$('{0:d2}' -f [int]$episodeNumber)`" " #Use $episodeNumber variable as metadata 'episode_id'
                 $ffArgs += "-metadata " #Flag to specify key/value pairs for encoding metadata
-                $ffArgs += "title=`"$episodeTitle`" " #Use $episodeTitleitle variable as metadata 'title'
+                $ffArgs += "title=`"$($episodeTitle.trim())`" " #Use $episodeTitleitle variable as metadata 'title'
+                $ffArgs += "-metadata " #Flag to specify key/value pairs for encoding metadata
+                $ffArgs += "comment=`"$unparsedTitle`" " #Use $episodeTitleitle variable as metadata 'title'
             }
             #Otherwise it's assumed to be a movie
             Else {
@@ -109,9 +111,8 @@ Function ConvertFile {
                 $ffArgs += "date=`"$year`" " #Use $year variable as metadata 'date'
             }
 
-            $encodingTool = "conv2mp4-$($prop.platform) $($prop.version) - $($prop.github_url)"
             $ffArgs += "-metadata " #Flag to specify key/value pairs for encoding metadata
-            $ffArgs += "encoding_tool=`"$encodingTool`" " #Use $encodingTool variable as metadata 'encoding_tool'
+            $ffArgs += "encoding_tool=`"$(PrintVersion)`" " #Use $encodingTool variable as metadata 'encoding_tool'
         }
 
         $ffArgs += "-map " #Flag to use channel mapping

--- a/files/func/ConvertFile.ps1
+++ b/files/func/ConvertFile.ps1
@@ -75,10 +75,16 @@ Function ConvertFile {
             $remove= $title | Select-String -Pattern '^(.*?)(19|20)[0-9]{2}(.*$)'  | ForEach-Object { "$($_.matches.groups[3])" }
             $title = $title -replace "$remove",''
             $title = $title -replace '\W',' '
-            $title = $title -replace '(\d{4})$', '($1)';
+            $year = $($title.split()[-1])
+            $title = $title.SubString(0, $title.LastIndexOf(' '))
+            $encodingTool = "conv2mp4-$($prop.platform) $($prop.version) - $($prop.github_url)"
 
             $ffArgs += "-metadata " #Flag to specify key/value pairs for encoding metadata
             $ffArgs += "title=`"$title`" " #Use $title variable as metadata 'Title'
+            $ffArgs += "-metadata " #Flag to specify key/value pairs for encoding metadata
+            $ffArgs += "date=`"$year`" " #Use $title variable as metadata 'Title'
+            $ffArgs += "-metadata " #Flag to specify key/value pairs for encoding metadata
+            $ffArgs += "encoding_tool=`"$encodingTool`" " #Use $title variable as metadata 'Title'
         }
 
         $ffArgs += "-map " #Flag to use channel mapping

--- a/files/func/ConvertFile.ps1
+++ b/files/func/ConvertFile.ps1
@@ -111,8 +111,9 @@ Function ConvertFile {
                 $ffArgs += "date=`"$year`" " #Use $year variable as metadata 'date'
             }
 
+            $encodingTool = "conv2mp4-$($prop.platform) $($prop.version) - $($prop.github_url)"
             $ffArgs += "-metadata " #Flag to specify key/value pairs for encoding metadata
-            $ffArgs += "encoding_tool=`"$(PrintVersion)`" " #Use $encodingTool variable as metadata 'encoding_tool'
+            $ffArgs += "encoding_tool=`"$encodingTool`" " #Use $encodingTool variable as metadata 'encoding_tool'
         }
 
         $ffArgs += "-map " #Flag to use channel mapping

--- a/files/func/ConvertFile.ps1
+++ b/files/func/ConvertFile.ps1
@@ -75,16 +75,18 @@ Function ConvertFile {
 
             #Check if it's a TV episode
             If ($title -match 's\d+'){
+                $regex = '^(.*?)(S\d+)(E\d+-?\s?E?\d*?)(\D+)(.*$)'
                 $unparsedTitle = $title
-                $remove = $title | Select-String -Pattern '^(.*?)(S\d+)(E\d+)(\D+)(.*$)'  | ForEach-Object { "$($_.matches.groups[5])" }
+                $remove = $title | Select-String -Pattern $regex  | ForEach-Object { "$($_.matches.groups[5])" }
                 $title = $title -replace "$remove",''
                 $title = $title -replace '\W',' '
-                $showTitle = $title | Select-String -Pattern '^(.*?)(S\d+)(E\d+)(\D+)(.*$)'  | ForEach-Object { "$($_.matches.groups[1])" }
-                $seasonNumber = $title | Select-String -Pattern '^(.*?)(S\d+)(E\d+)(\D+)(.*$)'  | ForEach-Object { "$($_.matches.groups[2])" }
+                $title = $($title.trim() -replace "\s+"," ")
+                $showTitle = $title | Select-String -Pattern $regex  | ForEach-Object { "$($_.matches.groups[1])" }
+                $seasonNumber = $title | Select-String -Pattern $regex  | ForEach-Object { "$($_.matches.groups[2])" }
                 $seasonNumber = $seasonNumber -replace 's',''
-                $episodeNumber = $title | Select-String -Pattern '^(.*?)(S\d+)(E\d+)(\D+)(.*$)'  | ForEach-Object { "$($_.matches.groups[3])" }
+                $episodeNumber = $title | Select-String -Pattern $regex  | ForEach-Object { "$($_.matches.groups[3])" }
                 $episodeNumber = $episodeNumber -replace 'e',''
-                $episodeTitle = $title | Select-String -Pattern '^(.*?)(S\d+)(E\d+)(\D+)(.*$)'  | ForEach-Object { "$($_.matches.groups[4])" }
+                $episodeTitle = $title | Select-String -Pattern $regex  | ForEach-Object { "$($_.matches.groups[4])" }
 
                 $ffArgs += "-metadata " #Flag to specify key/value pairs for encoding metadata
                 $ffArgs += "show=`"$($showTitle.trim())`" " #Use $showTitle variable as metadata 'show'
@@ -99,10 +101,11 @@ Function ConvertFile {
             }
             #Otherwise it's assumed to be a movie
             Else {
-                $remove= $title | Select-String -Pattern '^(.*?)(\(?)((19|20)[0-9]{2})(.*$)'  | ForEach-Object { "$($_.matches.groups[2,4,5])" }
+                $regex = '^(.*?)(\(?)((19|20)[0-9]{2})(.*$)'
+                $remove = $title | Select-String -Pattern $regex  | ForEach-Object { "$($_.matches.groups[2,4,5])" }
                 $title = $title -replace "$remove",''
                 $title = $title -replace '\W',' '
-                $title=$($title.trim() -replace "\s+"," ")
+                $title = $($title.trim() -replace "\s+"," ")
                 $year = $($title.split()[-1])
                 $title = $title.SubString(0, $title.LastIndexOf(' '))
 
@@ -112,9 +115,9 @@ Function ConvertFile {
                 $ffArgs += "date=`"$year`" " #Use $year variable as metadata 'date'
             }
 
-            $encodingTool = "Encoded by conv2mp4-$($prop.platform) v$($prop.version) ($($prop.github_url)) on $($time.Invoke())"
+            $encodeInformation = "Encoded by conv2mp4-$($prop.platform) v$($prop.version) ($($prop.github_url)) on $($time.Invoke())"
             $ffArgs += "-metadata " #Flag to specify key/value pairs for encoding metadata
-            $ffArgs += "comment=`"$encodingTool`" " #Use $encodingTool variable as metadata 'encoding_tool'
+            $ffArgs += "comment=`"$encodeInformation`" " #Use $encodingTool variable as metadata 'encoding_tool'
         }
 
         $ffArgs += "-map " #Flag to use channel mapping

--- a/files/func/ConvertFile.ps1
+++ b/files/func/ConvertFile.ps1
@@ -99,7 +99,7 @@ Function ConvertFile {
             }
             #Otherwise it's assumed to be a movie
             Else {
-                $remove= $title | Select-String -Pattern '^(.*?)(19|20)[0-9]{2}(.*$)'  | ForEach-Object { "$($_.matches.groups[3])" }
+                $remove= $title | Select-String -Pattern '^(.*?)(\(?)((19|20)[0-9]{2})(.*$)'  | ForEach-Object { "$($_.matches.groups[3])" }
                 $title = $title -replace "$remove",''
                 $title = $title -replace '\W',' '
                 $year = $($title.split()[-1])

--- a/files/init/preflight.ps1
+++ b/files/init/preflight.ps1
@@ -25,7 +25,7 @@ ValidateHandbrakeCLIPath -Path $cfg.handbrakecli_bin_dir
 Validatemedia_path -Path $cfg.media_path
 
 #Validate OutPath
-If ($cfg.use_out_path) {
+If ($cfg.use_out_path -eq 'true') {
     ValidateOutPath -Path $cfg.out_path
 }
 

--- a/files/prop/properties
+++ b/files/prop/properties
@@ -1,5 +1,5 @@
 #Version
-version=4.1.2
+version=4.1.3
 platform=ps
 
 #URLs

--- a/files/prop/properties
+++ b/files/prop/properties
@@ -1,5 +1,5 @@
 #Version
-version=4.1.3
+version=4.2
 platform=ps
 
 #URLs


### PR DESCRIPTION
- Closes #67  
- Closes #68 
- Intermediary file (target file) now takes on a non-media file extension (.conv2mp4) while encoding is underway in order to prevent it from being scanned/picked up by media scanners (Plex media scanner, etc.) before it is completed. The file extension is restored to .mp4 once encoding has completed.